### PR TITLE
replace boilerplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+mkdir -p content/documentation/modules/ROOT/pages/
+vi content/documentation/modules/ROOT/pages/index.adoc
+vi Makefile
+vi antora-playbook.yml
+vi content/documentation/antora.yml
+npx gulp bundle
+make antora.build
+make antora.run

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,0 +1,19 @@
+# antora-playbook.yml
+site:
+  robots: allow
+  start_page: sample-docs::index.adoc
+  title: Writing Samples
+  url: https://docs.example.com
+content:
+  sources:
+  - url: ./
+    branches: HEAD
+    start_paths:
+    - content/*
+runtime:
+  cache_dir: ./build/cache
+ui:
+  bundle:
+    url: ./build/ui-bundle.zip
+urls:
+  html_extension_style: indexify

--- a/antora.dockerfile
+++ b/antora.dockerfile
@@ -1,0 +1,4 @@
+# antora.dockerfile
+FROM antora/antora:3.1.7
+RUN yarn global add http-server onchange
+WORKDIR /srv/docs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,17 @@ version: '3'
 
 services:
 
+  antora:
+    build:
+      context: .
+      dockerfile: antora.dockerfile
+    environment:
+      CI: 'true'
+    ports:
+    - 8051:8080
+    volumes:
+    - .:/srv/docs
+
   ui:
     build:
       context: .


### PR DESCRIPTION
This PR sets Antora up to build from the `content/` dir and ignores the sample `docs/` dir.