### PR TITLE
nav and sample pages

### DIFF
--- a/content/documentation/antora.yml
+++ b/content/documentation/antora.yml
@@ -1,0 +1,5 @@
+name: sample-docs
+title: Writing Samples
+version: master
+nav:
+- modules/ROOT/nav.adoc

--- a/content/documentation/modules/ROOT/nav.adoc
+++ b/content/documentation/modules/ROOT/nav.adoc
@@ -1,0 +1,2 @@
+* xref:index.adoc#_welcome[Welcome!]
+* xref:docs-as-code.adoc[]

--- a/content/documentation/modules/ROOT/pages/docs-as-code.adoc
+++ b/content/documentation/modules/ROOT/pages/docs-as-code.adoc
@@ -1,0 +1,5 @@
+= Docs-As-Code
+
+== Overview
+
+words and links

--- a/content/documentation/modules/ROOT/pages/index.adoc
+++ b/content/documentation/modules/ROOT/pages/index.adoc
@@ -1,0 +1,5 @@
+= Sample Documentation
+
+== Overview
+
+words and links


### PR DESCRIPTION
This PR adds
- the `content/documentation/` directory
- `antora.yml` which sets the:
  - title
  - version to publish (need to find out how to replace `master`)
  - the file containing navigation
- `nav.adoc` which sets the pages and their position in the nav, and optionally overrides the name in the nav
- two pages, `index.adoc` and `docs-as-code.adoc`