### PR TITLE
version: master -> ~

### DIFF
--- a/content/documentation/antora.yml
+++ b/content/documentation/antora.yml
@@ -1,5 +1,5 @@
 name: sample-docs
 title: Writing Samples
-version: master
+version: ~
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
In version 3 Antora has deprecated use of `master` for current version of docs.